### PR TITLE
Add `keep_disabled!(reenable_in_child: false)`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
+Style/HashSyntax:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ end
 
 If for some reason you need to undo this, you can call `GrpcForkSafety.reenable!`
 
+Additionally, you can ask to keep GRPC disabled until `GrpcForkSafety.reenable!` is called explictly.
+This can be useful when using [Pitchfork](https://github.com/Shopify/pitchfork) reforking or similar, as to
+keep GRPC disabled in the mold.
+
+```ruby
+before_fork do
+  GrpcForkSafety.keep_disabled!(reenable_in_child: false)
+end
+```
+
 ### Hooks
 
 You can also register hooks to be called before GRPC is disabled and after it's re-enabled:


### PR DESCRIPTION
When using Pitchfork, `keep_disabled` isn't quite enough because `fork_sibling` use a double fork like daemonization, but also because you likely want GRPC to remain paused in the mold.

One thing to note though is that the `grpc` maintainer explicitly said `postfork_child` MUST be called in the immediate child, but I don't see why that is, so worth a try.